### PR TITLE
Fix infinitely increasing output in Infusion Table

### DIFF
--- a/src/main/java/com/stuintech/lacrimis/block/TaintBlock.java
+++ b/src/main/java/com/stuintech/lacrimis/block/TaintBlock.java
@@ -109,7 +109,8 @@ public class TaintBlock extends Block {
     @Override
     public void onBreak(World world, BlockPos pos, BlockState state, PlayerEntity player) {
         super.onBreak(world, pos, state, player);
-        player.addStatusEffect(new StatusEffectInstance(ModStatusEffects.TEAR_POISON, 300, 2));
+        if(!player.isCreative())
+            player.addStatusEffect(new StatusEffectInstance(ModStatusEffects.TEAR_POISON, 300, 2));
     }
 
     public boolean canReplace(BlockState state, ItemPlacementContext context) {

--- a/src/main/java/com/stuintech/lacrimis/block/entity/InfusionTableEntity.java
+++ b/src/main/java/com/stuintech/lacrimis/block/entity/InfusionTableEntity.java
@@ -57,6 +57,7 @@ public class InfusionTableEntity extends SoulTankEntity implements NamedScreenHa
 
             //Clear
             holding = ItemStack.EMPTY;
+            blockEntity.holding = holding;
             inventory.markDirty();
             tank.setTears(0);
             tank.setLimit(0);

--- a/src/main/java/com/stuintech/lacrimis/item/armor/SoakedArmor.java
+++ b/src/main/java/com/stuintech/lacrimis/item/armor/SoakedArmor.java
@@ -21,8 +21,8 @@ public class SoakedArmor extends ArmorItem {
     public void inventoryTick(ItemStack stack, World world, Entity entity, int slot, boolean selected) {
         super.inventoryTick(stack, world, entity, slot, selected);
         // 1% chance to take durability every tick
-        if (EnchantmentHelper.getLevel(ModEnchantments.WARDED, stack) <= 0 && Math.random() > 0.99)
-            stack.damage(1, new Random(), null);
+        if (EnchantmentHelper.getLevel(ModEnchantments.WARDED, stack) <= 0 && world.random.nextDouble() > 0.99)
+            stack.damage(1, world.random, null);
     }
 
 }


### PR DESCRIPTION
When you provide enough tears for the recipe to craft output ItemStack count will be increasing infinitely. This is because `holding` local variable is set to `ItemStack.EMPTY` but actual `BlockEntity.holding` field still contains old `ItemStack`